### PR TITLE
Return object of dependencies to update in programmatic interface

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -25,9 +25,10 @@ function test(pkg, done) {
 }
 
 test(pkg_out_of_date, function (err, status) {
-  assert(status === false, 'should respond with a falsy status if upgrade is suggested');
+  assert.deepEqual(status, pkg_up_to_date.dependencies,
+    'should respond with an object of dependencies to update');
   test(pkg_up_to_date, function (err, status) {
-    assert(status === true, 'should respond with a truthy status if up to date');
+    assert(status === null, 'should respond with null if up to date');
     process.exit(0);
   });
 });


### PR DESCRIPTION
This changes the programmatic interface so that it will call `done(err, dependenciesToUpdate)` with an object of dependencies to update as its second argument. It will be in the form: `{depName: latestDepUrl}`. If there are no dependencies to update, it will pass `null`. 

This is a breaking change because it used to return `true` when there were no dependencies to update and `false` when there were.
